### PR TITLE
feat: wire compute.device through to OTDD for GPU acceleration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,13 @@ The `themap` command is installed as a console script. All commands support `--h
 # Quick distance computation (no config file needed)
 themap quick datasets/ -f ecfp -m euclidean -o output/
 themap quick datasets/ -f maccs -m cosine
+themap quick datasets/ -f ecfp -m otdd --device cuda  # GPU-accelerated OTDD
 
 # Full pipeline with YAML config
 themap init                              # generate config.yaml template
 themap run config.yaml                   # run pipeline
 themap run config.yaml -o results/ -j 4  # custom output dir and parallelism
+themap run config.yaml --device cuda     # force GPU (OTDD); 'auto' is default
 themap run config.yaml --molecule-only   # skip protein distances
 
 # Pre-compute and cache features (no distance computation)

--- a/tests/unit/distance/test_dataset_distance.py
+++ b/tests/unit/distance/test_dataset_distance.py
@@ -1,0 +1,45 @@
+"""Tests for ``themap.distance.dataset_distance`` helpers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from themap.distance.dataset_distance import _resolve_device
+
+
+class TestResolveDevice:
+    """Tests for the ``_resolve_device`` helper."""
+
+    def test_explicit_cpu_passthrough(self):
+        assert _resolve_device("cpu") == "cpu"
+
+    def test_explicit_cuda_passthrough(self):
+        assert _resolve_device("cuda") == "cuda"
+
+    def test_explicit_indexed_cuda_passthrough(self):
+        assert _resolve_device("cuda:1") == "cuda:1"
+
+    def test_auto_resolves_to_cuda_when_available(self):
+        with patch("torch.cuda.is_available", return_value=True):
+            assert _resolve_device("auto") == "cuda"
+
+    def test_auto_resolves_to_cpu_when_no_gpu(self):
+        with patch("torch.cuda.is_available", return_value=False):
+            assert _resolve_device("auto") == "cpu"
+
+    def test_auto_falls_back_to_cpu_when_torch_missing(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("torch not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert _resolve_device("auto") == "cpu"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/themap/cli.py
+++ b/themap/cli.py
@@ -49,6 +49,12 @@ def cli(ctx: click.Context, verbose: bool) -> None:
 @click.option("--molecule-only", is_flag=True, help="Only compute molecule distances")
 @click.option("--protein-only", is_flag=True, help="Only compute protein distances")
 @click.option("--n-jobs", "-j", type=int, help="Number of parallel jobs")
+@click.option(
+    "--device",
+    type=click.Choice(["auto", "cpu", "cuda"]),
+    default=None,
+    help="Device for OTDD ('auto' picks cuda if available). Overrides config.",
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -57,6 +63,7 @@ def run(
     molecule_only: bool,
     protein_only: bool,
     n_jobs: Optional[int],
+    device: Optional[str],
 ) -> None:
     """Run the distance computation pipeline.
 
@@ -66,6 +73,7 @@ def run(
         themap run config.yaml
         themap run config.yaml --output results/
         themap run config.yaml --molecule-only
+        themap run config.yaml --device cuda
     """
     from .pipeline import Pipeline
 
@@ -85,6 +93,9 @@ def run(
 
     if n_jobs:
         cfg.compute.n_jobs = n_jobs
+
+    if device:
+        cfg.compute.device = device
 
     # Validate
     issues = cfg.validate()
@@ -249,12 +260,19 @@ def list_featurizers() -> None:
 @click.option("--featurizer", "-f", default="ecfp", help="Molecule featurizer")
 @click.option("--method", "-m", default="euclidean", help="Distance method")
 @click.option("--n-jobs", "-j", default=8, help="Number of parallel jobs")
+@click.option(
+    "--device",
+    type=click.Choice(["auto", "cpu", "cuda"]),
+    default="auto",
+    help="Device for OTDD ('auto' picks cuda if available).",
+)
 def quick(
     data_dir: str,
     output: str,
     featurizer: str,
     method: str,
     n_jobs: int,
+    device: str,
 ) -> None:
     """Quick distance computation with minimal configuration.
 
@@ -263,6 +281,7 @@ def quick(
     Examples:
         themap quick datasets/TDC/
         themap quick datasets/TDC/ --featurizer maccs --method cosine
+        themap quick datasets/TDC/ -m otdd --device cuda
     """
     from .pipeline import quick_distance
 
@@ -270,6 +289,7 @@ def quick(
     click.echo(f"  Featurizer: {featurizer}")
     click.echo(f"  Method: {method}")
     click.echo(f"  Workers: {n_jobs}")
+    click.echo(f"  Device: {device}")
 
     try:
         results = quick_distance(
@@ -278,6 +298,7 @@ def quick(
             molecule_featurizer=featurizer,
             molecule_method=method,
             n_jobs=n_jobs,
+            device=device,
         )
 
         click.echo("\nResults:")

--- a/themap/distance/dataset_distance.py
+++ b/themap/distance/dataset_distance.py
@@ -47,6 +47,23 @@ def _matrix_to_dict(
     }
 
 
+def _resolve_device(device: str) -> str:
+    """Resolve ``"auto"`` to ``"cuda"`` when a GPU is available, else ``"cpu"``.
+
+    Explicit values (``"cpu"``, ``"cuda"``, ``"cuda:0"`` ...) are returned as-is
+    so callers can still pin a specific device. If torch is unavailable for any
+    reason, fall back to ``"cpu"``.
+    """
+    if device != "auto":
+        return device
+    try:
+        import torch
+
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except ImportError:
+        return "cpu"
+
+
 def _compute_prototype(
     features: NDArray[np.float32],
     labels: NDArray[np.int32],
@@ -131,6 +148,7 @@ class DatasetDistance:
         source_ids: List[str],
         target_ids: List[str],
         n_jobs: int = 1,
+        device: str = "auto",
         **kwargs: Any,
     ) -> DistanceMatrix:
         """Compute N×M distance matrix between source and target datasets.
@@ -143,6 +161,9 @@ class DatasetDistance:
             source_ids: List of N source task identifiers
             target_ids: List of M target task identifiers
             n_jobs: Number of parallel jobs (for OTDD)
+            device: Device for OTDD computation. ``"auto"`` (default) uses CUDA
+                when available, else CPU. Accepts any torch device string.
+                Ignored by Euclidean/Cosine (scipy.cdist, CPU-only).
             **kwargs: Additional arguments for specific methods
 
         Returns:
@@ -162,6 +183,7 @@ class DatasetDistance:
                 source_ids,
                 target_ids,
                 n_jobs,
+                device=device,
                 **kwargs,
             )
         else:
@@ -215,14 +237,17 @@ class DatasetDistance:
         target_ids: List[str],
         n_jobs: int,
         maxsamples: int = 1000,
+        device: str = "auto",
         **kwargs: Any,
     ) -> DistanceMatrix:
         """Compute distance matrix using OTDD.
 
         OTDD is more expensive but considers both feature and label distributions.
         """
+        resolved_device = _resolve_device(device)
         logger.info(
-            f"Computing {len(target_ids)}×{len(source_ids)} OTDD distance matrix (maxsamples={maxsamples})"
+            f"Computing {len(target_ids)}×{len(source_ids)} OTDD distance matrix "
+            f"(maxsamples={maxsamples}, device={resolved_device})"
         )
 
         try:
@@ -278,7 +303,7 @@ class DatasetDistance:
         distances: DistanceMatrix = {}
         hopts = {
             "maxsamples": maxsamples,
-            "device": "cpu",
+            "device": resolved_device,
             "verbose": 1 if logger.isEnabledFor(logging.DEBUG) else 0,
             **kwargs,
         }
@@ -352,6 +377,7 @@ def compute_dataset_distance_matrix(
     target_ids: List[str],
     method: DatasetDistanceMethod = "euclidean",
     n_jobs: int = 1,
+    device: str = "auto",
     **kwargs: Any,
 ) -> DistanceMatrix:
     """Convenience function to compute dataset distance matrix.
@@ -368,6 +394,8 @@ def compute_dataset_distance_matrix(
         target_ids: List of M target task identifiers
         method: Distance method ('otdd', 'euclidean', 'cosine')
         n_jobs: Number of parallel jobs
+        device: Device for OTDD (``"auto" | "cpu" | "cuda"``). ``"auto"`` picks
+            CUDA when available. Ignored by Euclidean/Cosine.
         **kwargs: Additional method-specific arguments
 
     Returns:
@@ -390,5 +418,6 @@ def compute_dataset_distance_matrix(
         source_ids,
         target_ids,
         n_jobs=n_jobs,
+        device=device,
         **kwargs,
     )

--- a/themap/pipeline/orchestrator.py
+++ b/themap/pipeline/orchestrator.py
@@ -212,6 +212,7 @@ class Pipeline:
             target_ids=test_ids,
             method=cast(Literal["otdd", "euclidean", "cosine"], self.config.molecule.method),
             n_jobs=self.config.compute.n_jobs,
+            device=self.config.compute.device,
         )
 
     def _load_or_compute_molecule_features(
@@ -411,6 +412,7 @@ def quick_distance(
     molecule_featurizer: str = "ecfp",
     molecule_method: str = "euclidean",
     n_jobs: int = 8,
+    device: str = "auto",
 ) -> Dict[str, DistanceMatrix]:
     """Quick distance computation with minimal configuration.
 
@@ -420,6 +422,8 @@ def quick_distance(
         molecule_featurizer: Molecule featurizer name.
         molecule_method: Distance method.
         n_jobs: Number of parallel jobs.
+        device: Device for OTDD (``"auto" | "cpu" | "cuda"``). Ignored by
+            Euclidean/Cosine.
 
     Returns:
         Dictionary of distance matrices.
@@ -440,7 +444,7 @@ def quick_distance(
             method=molecule_method,
         ),
         output=OutputConfig(directory=Path(output_dir)),
-        compute=ComputeConfig(n_jobs=n_jobs),
+        compute=ComputeConfig(n_jobs=n_jobs, device=device),
     )
 
     pipeline = Pipeline(config)


### PR DESCRIPTION
## Summary

- Threads the existing `ComputeConfig.device` field end-to-end so OTDD actually runs on GPU when requested. Previously `_compute_otdd_matrix` hardcoded `device=\"cpu\"`, making `compute.device: cuda` in config and the `-j` CLI flag silently fall back to CPU regardless of user intent.
- Adds `--device [auto|cpu|cuda]` CLI option on `themap run` (overrides config) and `themap quick` (default `auto`, picks cuda when available).
- Adds `_resolve_device()` helper + 6 unit tests covering the resolution logic and `ImportError` fallback when torch is unavailable.

## What changed

- `themap/distance/dataset_distance.py`: new `_resolve_device()`; `device` param threaded through `DatasetDistance.compute_matrix`, `_compute_otdd_matrix`, and `compute_dataset_distance_matrix`; replaced hardcoded `\"cpu\"` at line 281; log line now reports the resolved device alongside `maxsamples`.
- `themap/pipeline/orchestrator.py`: `Pipeline._compute_molecule_distances` passes `device=self.config.compute.device`; `quick_distance()` accepts `device` and plumbs it into `ComputeConfig`.
- `themap/cli.py`: `--device` added to `run` and `quick`.
- `tests/unit/distance/test_dataset_distance.py`: 6 new tests for `_resolve_device` (explicit passthrough including `cuda:1`, `auto` → cuda when available, `auto` → cpu without GPU, and ImportError fallback).
- `CLAUDE.md`: two CLI example lines showing `--device cuda`.

## Test plan

- [x] `ruff check` / `ruff format` clean on modified files
- [x] `mypy -p themap` passes (68 source files, no issues)
- [x] `python run_tests.py distance` — 40/40 passed (including the 6 new tests)
- [x] `python run_tests.py fast` — 233/233 passed
- [x] End-to-end smoke test on committed `datasets/`: `themap quick datasets/ -m otdd --device cuda` logs `device=cuda` and produces finite results
- [x] Numerical agreement CPU vs GPU: pairs finite on both runs agree within **0.65% max relative difference** (well within OTDD's `maxsamples=1000` sampling noise)

## Backward compatibility

Default is `\"auto\"`, which resolves to `\"cpu\"` when `torch.cuda.is_available()` is `False` — preserves current behavior on CPU-only CI and machines without a GPU.

## Non-goals (deferred follow-ups)

- No outer-loop joblib parallelism over the N×M grid (would fight over a single GPU; only useful on CPU-only clusters).
- No refactor of the duplicated `ComputeConfig` between \`themap/config.py\` and \`themap/pipeline/config.py\`.
- No deprecation of the legacy \`TaskDistance\` / \`MoleculeDatasetDistance\` / \`ProteinDatasetDistance\` APIs.
- \`themap featurize\` CLI did not get a \`--device\` flag because its existing \`--n-jobs\` is also not plumbed through and \`featurize\` does not run OTDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)