### PR TITLE
chore(ci): harden CI/CD workflows and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
     labels:
       - "dependencies"
       - "github_actions"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,15 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Least privilege: linting only needs to read the repository.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -25,6 +34,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,9 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
+        # No uv.lock in this repo; key the cache off pyproject.toml instead of
+        # the default **/uv.lock glob (which errors when nothing matches).
+        cache-dependency-glob: "pyproject.toml"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,46 @@
+name: Pre-commit autoupdate
+
+# Dependabot has no pre-commit ecosystem, so we bump hook revisions on a
+# schedule and open a PR. Keeps .pre-commit-config.yaml hooks current.
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # commit the updated config
+      pull-requests: write  # open the PR
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run pre-commit autoupdate
+        run: |
+          pipx run pre-commit autoupdate
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(pre-commit): autoupdate hook revisions"
+          title: "chore(pre-commit): autoupdate hook revisions"
+          body: |
+            Automated weekly `pre-commit autoupdate`.
+
+            Note: ruff's hook `rev` must stay in sync with the pinned
+            `ruff==0.12.4` in `pyproject.toml` / CI. If this PR bumps ruff,
+            update those pins together (or revert the ruff change).
+          branch: chore/pre-commit-autoupdate
+          labels: |
+            dependencies
+            pre-commit
+          delete-branch: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,38 +2,61 @@ name: Build and Publish
 
 on:
   release:
-    types: [created]
+    # "published" (not "created") so draft releases do not trigger a publish.
+    types: [published]
   workflow_dispatch:
 
+# Default to read-only; the publish job opts into the OIDC token it needs.
+permissions:
+  contents: read
+
 jobs:
-  deploy:
+  # Build the distribution once. The package is pure-Python (a single
+  # py3-none-any wheel + sdist), so there is no need for a Python matrix here —
+  # building/publishing per version would produce identical artifacts and the
+  # duplicate uploads would fail.
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from git tags/history.
+          fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      - name: Build sdist and wheel
+        run: pipx run build
 
-    - name: Install dependencies
-      run: |
-        uv pip install --system build twine
+      - name: Check distribution metadata
+        run: pipx run twine check --strict dist/*
 
-    - name: Build and package
-      run: |
-        python -m build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
-    - name: Publish to PyPI
-      if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish for an actual GitHub release (not workflow_dispatch dry runs).
+    if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/themap/
+    permissions:
+      # Required for PyPI Trusted Publishing (OIDC); no stored API token needed.
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
+        # No uv.lock in this repo; key the cache off pyproject.toml instead of
+        # the default **/uv.lock glob (which errors when nothing matches).
+        cache-dependency-glob: "pyproject.toml"
 
     - name: Install dependencies
       run: |
@@ -69,6 +72,9 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
+        # No uv.lock in this repo; key the cache off pyproject.toml instead of
+        # the default **/uv.lock glob (which errors when nothing matches).
+        cache-dependency-glob: "pyproject.toml"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,15 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Least privilege: building/testing only needs read access.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -28,6 +37,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
 
     - name: Install dependencies
       run: |
@@ -40,7 +51,8 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
 
   docs:
@@ -55,6 +67,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Addresses CI/CD best-practice gaps found in a review of the pre-commit, CI, and CD configuration. No application code changes.

## Changes

### 🔴 `publish.yml` — fix a release-breaking bug + harden
- **Bug:** the publish job ran across a `3.10/3.11/3.12` matrix and built+published on each. The package is pure-Python (one `py3-none-any` wheel + sdist), so all three produced identical artifacts and the 2nd/3rd uploads would fail with "file already exists." → now a **single build job**.
- **PyPI Trusted Publishing (OIDC)** via `id-token: write` instead of a long-lived `PYPI_API_TOKEN` secret.
- Adds `twine check --strict dist/*`; uploads the built dist as an artifact consumed by a separate `publish` job.
- Triggers on `release: published` (not draft `created`).

### 🟠 `lint.yml` / `test.yml`
- Least-privilege top-level `permissions: contents: read`.
- `concurrency:` group to cancel superseded runs on the same ref.
- Enable `uv` caching (`enable-cache: true`) — installs pull torch/dgl/esm/pykeops, so this is a meaningful speedup.
- Codecov: pass `token: ${{ secrets.CODECOV_TOKEN }}` and use the non-deprecated `files:` input.

### 🟡 Dependabot + pre-commit
- Add the **`pip`** ecosystem so Python dependencies get weekly update PRs (previously only `github-actions` was covered).
- Dependabot has **no** `pre-commit` ecosystem, so added a scheduled **`pre-commit-autoupdate.yml`** workflow that runs `pre-commit autoupdate` weekly and opens a PR bumping hook revisions.

## ⚠️ Required manual setup before the next release
1. **PyPI Trusted Publishing:** on PyPI → project `themap` → *Publishing*, add a GitHub trusted publisher: repo `HFooladi/THEMAP`, workflow `publish.yml`, environment `pypi`. (Until then, releases won't authenticate.)
2. **GitHub environment:** create an environment named `pypi` (optionally with protection rules/required reviewers).
3. Once trusted publishing works, the `PYPI_API_TOKEN` secret can be deleted.
4. Optional: add a `CODECOV_TOKEN` secret (Codecov v4 generally needs it now).

## Validation
All workflow/Dependabot YAML parses cleanly (`yaml.safe_load`). `actionlint` couldn't run in this environment (no Go toolchain; Docker daemon not accessible), so a maintainer eye on the Actions tab for the first run is worth it.

## Follow-up (not done here, to keep the diff focused)
- Pinning actions to commit SHAs instead of `@v4` tags (hardened supply-chain practice; Dependabot still bumps them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)